### PR TITLE
Add conditional login/register link

### DIFF
--- a/src/components/forms/FormC.jsx
+++ b/src/components/forms/FormC.jsx
@@ -287,11 +287,17 @@ const FormC = ({ idPage }) => {
                 >
                   {idPage === "registrarse" ? "Registrarse" : "Iniciar Sesión"}
                 </Button>
-                 <div className="mt-2">
-        <Link to="/recuperarcontrasenia">
-          ¿Olvidaste tu contraseña?
-        </Link>
-      </div>
+                <div className="mt-2">
+                  {idPage === "registrarse" ? (
+                    <Link to="/iniciarsesion">
+                      ¿Ya tenés una cuenta? Iniciar sesión
+                    </Link>
+                  ) : (
+                    <Link to="/recuperarcontrasenia">
+                      ¿Olvidaste tu contraseña?
+                    </Link>
+                  )}
+                </div>
               </Form>
             </div>
           </Col>


### PR DESCRIPTION
## Summary
- tweak `FormC.jsx` link at the bottom so registration page prompts for login
- keep forgotten password link on login page

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68686416f48483319c1e2ae4e5dc02ec